### PR TITLE
Update DVB-C tuning frequencies

### DIFF
--- a/cdk/root_dream/var_init/etc/cables_locale.xml
+++ b/cdk/root_dream/var_init/etc/cables_locale.xml
@@ -54,7 +54,7 @@ Committed to the C16 GitHub by AL on Wed 18 Jan 2017 with credits :)
 	<transponder frequency="619000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="5" netid="40982" name="40982 Dundee (Edinburgh 2 SCOTLAND)"/>
 	<transponder frequency="539000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="5" netid="40983" name="40983 TTA Knowsley DMC (Hayes_RHE)"/>
 	<transponder frequency="619000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="5" netid="40984" name="40984 Uddingston (SCOTLAND)"/>
-	<transponder frequency="595000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="3" netid="40985" name="40985 Haringey"/>
+	<transponder frequency="595000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="5" netid="40985" name="40985 Haringey"/>
 	<transponder frequency="595000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="5" netid="40986" name="40986 NGRHEE Knowsley"/>
 	<transponder frequency="403000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="3" netid="40987" name="40987 Exeter"/>
 	<transponder frequency="403000" inversion="2" symbol_rate="6952" fec_inner="3" modulation="3" netid="40988" name="40988 Plymouth"/>

--- a/cdk/root_dream/var_init/etc/info/cable_SML_NetID_help.txt
+++ b/cdk/root_dream/var_init/etc/info/cable_SML_NetID_help.txt
@@ -21,7 +21,7 @@ mate or neighbour who DOES have a subbed box and ask them to help you?
 
 Now on your dm500c box, using C16 from 08 Jan 2017 or later, go into the SCAN
 menu and manually enter your 5 digit NetID, your 6 digit Frequency, and
-then toggle your Symrate to 6875, , or  (there can only be one!). You
+then toggle your Symrate to 6875, 6887, or 6952 (there can only be one!). You
 do this by highlighting the <Scan-Modes One Transponder> line then click OK
 and then enter YOUR local data in the required fields. Then SAVE settings!
 

--- a/cdk/root_dream/var_init/etc/info/cable_SML_NetID_help.txt
+++ b/cdk/root_dream/var_init/etc/info/cable_SML_NetID_help.txt
@@ -20,8 +20,8 @@ are not subbed, then consider yourself naughty and frowned upon... Try a nearby
 mate or neighbour who DOES have a subbed box and ask them to help you?
 
 Now on your dm500c box, using C16 from 08 Jan 2017 or later, go into the SCAN
-menu and manually enter your 5 digit NetID, your 6 digit Frequency, and 
-then toggle your Symrate to 6875, 6887, or 6952 (there can only be one!). You
+menu and manually enter your 5 digit NetID, your 6 digit Frequency, and
+then toggle your Symrate to 6875, , or  (there can only be one!). You
 do this by highlighting the <Scan-Modes One Transponder> line then click OK
 and then enter YOUR local data in the required fields. Then SAVE settings!
 
@@ -42,111 +42,111 @@ NetID City/Town/Area Frequency SymRate
 
 NetIDS 00001 to 00025 (ntl Pure areas)
 --------------------------------------
-00001 West Yorkshire:	643000 6887
-00002 Glasgow:			643000 6887
-00003 Farnborough:		643000 6887
-00004 Bridgend:			643000 6887
-00005 Luton:			643000 6887
-00006 Swindon:			643000 6887
-00007 Port Talbot:		643000 6887
-00008 Nottingham:		643000 6887
-00009 Cambridge:		643000 6887
-00010 Teesside:			643000 6887
-00011 Ipswich:			643000 6887
-00012 Leicester:		643000 6887
-00013 Reading:			643000 6887
-00014 Salisbury:		643000 6887
-00015 Lichfield:		643000 6887
-00016 Warwick:			643000 6887
-00017 Hemel:			643000 6887
-00018 Northampton:		643000 6887
-00019 Coventry:			643000 6887
-00020 Oxford:			643000 6887
-00021 Belfast:			643000 6887
-00022 Grimsby:			643000 6887
-00023 Derry:			643000 6952
+00001 West Yorkshire:	643000
+00002 Glasgow:			643000
+00003 Farnborough:		643000
+00004 Bridgend:			643000
+00005 Luton:			643000
+00006 Swindon:			643000
+00007 Port Talbot:		643000
+00008 Nottingham:		643000
+00009 Cambridge:		643000
+00010 Teesside:			643000
+00011 Ipswich:			643000
+00012 Leicester:		643000
+00013 Reading:			643000
+00014 Salisbury:		643000
+00015 Lichfield:		643000
+00016 Warwick:			643000
+00017 Hemel:			643000
+00018 Northampton:		643000
+00019 Coventry:			643000
+00020 Oxford:			643000
+00021 Belfast:			643000
+00022 Grimsby:			643000
+00023 Derry:			643000
 
 NetIDS 40961 to 40999 (ex-C&W and TeleWest areas)
 -------------------------------------------------
-40961 Barnsley:			595000 6952
-40962 Barnsley:			595000 6952
-40963 Sheffield:		595000 6952
-40964 Sheffield:		595000 6952
-40965 Knowsley:			595000 6952
-40966 Knowsley:			595000 6952
-40967 Preston:			595000 6952
-40968 Preston:			595000 6952
-40969 Gateshead:		571000 6952
-40970 Bristol:			651000 6952
-40971 Bristol:			651000 6952
-40973 Wolverhampton:	595000 6952
-40974 Wolverhampton:	595000 6952
-40975 Basildon:			411000 6952
-40976 Basildon:			411000 6952
-40977 Basildon:			411000 6952
-40978 Basildon:			411000 6952
-40979 Croydon:			411000 6952
-40980 Hayes:			539000 6952
-40981 Edinburgh:		619000 6952
-40982 Dundee:			619000 6952
-40983 Knowsley:			539000 6952
-40984 Uddingston:		619000 6952
-40985 Haringey:			603000 6952
-40986 Knowsley:			595000 6952
-40987 Exeter:			643000 6952
-40988 Plymouth:			643000 6952
-40990 Barnsley:			595000 6952
-40995 Wolverhampton:	595000 6952
-40998 Barnsley:			595000 6952
-40999 Perth:			619000 6952
-41003 Carlisle:			619000 6952
-41008 Liverpool:		595000 6952
-41009 Falkirk:			619000 6952
-41011 Birmingham:		643000 6952
-41013 Knowsley:			595000 6952
-41015 Birmingham:		595000 6952
-41016 Liverpool:		595000 6952
-41018 Preston:			595000 6952
-41020 Crawley:			411000 6952
-41026 Southport:		595000 6952
-41040 Leeds:			666750 6952
-41041 Bromley:			666750 6952
-41042 Portsmouth:		666750 6952
-41043 Poole:			666750 6952
-41044 Brighton:			666750 6952
-41045 Hersham:			666750 6952
-41046 Derby:			666750 6952
-41048 Manchester:		666750 6952
-41049 Peterborough:		666750 6952
-41050 Seven Kings:		666750 6952
-41051 Watford:			666750 6952
-41052 Ashford:			666750 6952
-41053 Leeds:			666750 6952
-41054 Wearside:			666750 6952
-41055 Norwich:			666750 6952
-41056 Bromley:			666750 6952
-41059 Brighton:			666750 6952
-41060 Manchester:		666750 6952
-41063 Stoke:			666750 6952
-41064 York:				666750 6952
-41065 Portsmouth:		666750 6952
-41066 Manchester:		666750 6952
-41067 Bromley:			666750 6952
-41068 Manchester:		666750 6952
-41069 Lewisham:			666750 6952
-41071 Southampton:		666750 6952
+40961 Barnsley:			595000
+40962 Barnsley:			595000
+40963 Sheffield:		595000
+40964 Sheffield:		595000
+40965 Knowsley:			595000
+40966 Knowsley:			595000
+40967 Preston:			595000
+40968 Preston:			595000
+40969 Gateshead:		571000
+40970 Bristol:			651000
+40971 Bristol:			651000
+40973 Wolverhampton:	595000
+40974 Wolverhampton:	595000
+40975 Basildon:			411000
+40976 Basildon:			411000
+40977 Basildon:			411000
+40978 Basildon:			411000
+40979 Croydon:			411000
+40980 Hayes:			539000
+40981 Edinburgh:		619000
+40982 Dundee:			619000
+40983 Knowsley:			539000
+40984 Uddingston:		619000
+40985 Haringey:			595000
+40986 Knowsley:			595000
+40987 Exeter:			643000
+40988 Plymouth:			643000
+40990 Barnsley:			595000
+40995 Wolverhampton:	595000
+40998 Barnsley:			595000
+40999 Perth:			619000
+41003 Carlisle:			619000
+41008 Liverpool:		595000
+41009 Falkirk:			619000
+41011 Birmingham:		643000
+41013 Knowsley:			595000
+41015 Birmingham:		595000
+41016 Liverpool:		595000
+41018 Preston:			595000
+41020 Crawley:			411000
+41026 Southport:		595000
+41040 Leeds:			666750
+41041 Bromley:			666750
+41042 Portsmouth:		666750
+41043 Poole:			666750
+41044 Brighton:			666750
+41045 Hersham:			666750
+41046 Derby:			666750
+41048 Manchester:		666750
+41049 Peterborough:		666750
+41050 Seven Kings:		666750
+41051 Watford:			666750
+41052 Ashford:			666750
+41053 Leeds:			666750
+41054 Wearside:			666750
+41055 Norwich:			666750
+41056 Bromley:			666750
+41059 Brighton:			666750
+41060 Manchester:		666750
+41063 Stoke:			666750
+41064 York:				666750
+41065 Portsmouth:		666750
+41066 Manchester:		666750
+41067 Bromley:			666750
+41068 Manchester:		666750
+41069 Lewisham:			666750
+41071 Southampton:		666750
 
 NetIDS 42001 and above (Éire)
 -----------------------------
-42753 Dublin:			643000 6887
-42754 Waterford:		643000 6887
-42757 Waterford:		643000 6887
-43216 Cork:				291000 6887
-43217 Dublin:			299000 6887
-43218 Galway City:		291000 6887
-43219 WatUPC:			291000 6887
-43220 Lim_UPC:			291000 6887
-43226 Meath:			340000 6875
+42753 Dublin:			643000
+42754 Waterford:		643000
+42757 Waterford:		643000
+43216 Cork:				291000
+43217 Dublin:			299000
+43218 Galway City:		291000
+43219 WatUPC:			291000
+43220 Lim_UPC:			291000
+43226 Meath:			340000
 
 ### STILL no idea of your NetID? Don't despair! ###
 ===================================================
@@ -176,7 +176,7 @@ Now repeat this exercise for the vanilla-named "ITV" channels. Same applies
 as above. You might get one or two working ones?
 
 Then find your working "ITV +1", "Channel 4" and "Channel 5" regionals and
-nuke the non-working ones! 
+nuke the non-working ones!
 
 SAVE whenever prompted, if you're happy with your edits to Bouquets!!!
 
@@ -189,4 +189,3 @@ DM500C box... You've been warned!
 With a tested and working backup, you can easily recover, if necessary!
 
 All good fun... ;)
-


### PR DESCRIPTION
Remove symbol rate values as these are mostly out of date and being replaced with 6952